### PR TITLE
feat(frontend): Add display for a state where a match is confirmed and user is redirecting to the session

### DIFF
--- a/frontend/src/features/matching/matchFoundModal/matchFoundModal.tsx
+++ b/frontend/src/features/matching/matchFoundModal/matchFoundModal.tsx
@@ -14,6 +14,7 @@ interface PartnerDetails {
 
 interface MatchFoundModalProps {
   partner: PartnerDetails;
+  hasPartnerAccepted: boolean;
   onAccept: () => void;
   onDecline: () => void;
   criteria: any;
@@ -23,6 +24,7 @@ interface MatchFoundModalProps {
 
 const MatchFoundModal = ({
                            partner,
+                           hasPartnerAccepted,
                            onAccept,
                            onDecline,
                            criteria,
@@ -141,12 +143,21 @@ const MatchFoundModal = ({
 
 
         {isWaitingForPartner
-          ? (
-            <div className={styles.waitingContainer}>
-              <div className={styles.spinner}></div>
-              <h2>Waiting for partner...</h2>
-              <p className={styles.subtitle}>Your partner has been notified.</p>
-            </div>
+          ? (hasPartnerAccepted
+            ? (
+              <div className={styles.waitingContainer}>
+                <div className={styles.spinner}></div>
+                <h2>Match Confirmed!</h2>
+                <p className={styles.subtitle}>Redirecting to session room...</p>
+              </div>
+            )
+            : (
+                <div className={styles.waitingContainer}>
+                  <div className={styles.spinner}></div>
+                  <h2>Waiting for partner...</h2>
+                  <p className={styles.subtitle}>Your partner has been notified.</p>
+               </div>
+              )
           ) : (
             <>
               <div className={styles.timerContainer}>

--- a/frontend/src/features/matching/matchingStatusModal/matchingStatusModal.tsx
+++ b/frontend/src/features/matching/matchingStatusModal/matchingStatusModal.tsx
@@ -147,7 +147,7 @@ const MatchingStatusModal = ({
         <ProgressBar progress={progressPercent} />
         <p className={styles.timerText}>Searching... {timer}s remaining</p>
 
-        <StatsDisplay usersOnline={usersOnline} avgWaitTime={avgWaitTime} />
+        {/*<StatsDisplay usersOnline={usersOnline} avgWaitTime={avgWaitTime} />*/}
 
         <CancelButton onClick={onCancel} disabled={disabled} />
       </div>

--- a/frontend/src/features/matching/practiceSessionForm/practiceSessionForm.tsx
+++ b/frontend/src/features/matching/practiceSessionForm/practiceSessionForm.tsx
@@ -412,6 +412,7 @@ const PracticeSessionForm = () => {
       {showMatchModal && partnerDetails && matchData && (
         <MatchFoundModal
           partner={partnerDetails}
+          hasPartnerAccepted={partnerHasAccepted}
           onAccept={() => handleAccept()}
           onDecline={() => handleDecline()}
           criteria={matchData.criteria}

--- a/matching-service/src/services/matchingService.ts
+++ b/matching-service/src/services/matchingService.ts
@@ -185,16 +185,16 @@ export const findOrQueueUser = async (userId: string, criteria: MatchCriteria) =
   await redisClient.del(cancelKey);
 
   // Check for penalty
-  const cooldownKey = `${COOLDOWN_KEY_PREFIX}${userId}`;
-  const penaltyTtl = await redisClient.ttl(cooldownKey);
+  // const cooldownKey = `${COOLDOWN_KEY_PREFIX}${userId}`;
+  // const penaltyTtl = await redisClient.ttl(cooldownKey);
 
-  if (penaltyTtl > 0) {
-    console.log(`User ${userId} is on cooldown. ${penaltyTtl}s remaining.`);
-    return {
-      status: 'penalized',
-      cooldown: penaltyTtl
-    };
-  }
+  // if (penaltyTtl > 0) {
+  //   console.log(`User ${userId} is on cooldown. ${penaltyTtl}s remaining.`);
+  //   return {
+  //     status: 'penalized',
+  //     cooldown: penaltyTtl
+  //   };
+  // }
 
   // Encode the user's criteria into their "Searcher Mask"
   const searcherMask = encodeCriteria(criteria);
@@ -409,8 +409,12 @@ export const handleWebSocketConnection = (ws: WebSocket) => {
 
             if (match.user1Status === 'accepted' && match.user2Status === 'accepted') {
               console.log(`Match ${parsedMessage.matchId} confirmed!`);
-
               handleMatchConfirmed(match, parsedMessage.matchId);
+            } else {
+              // match NOT YET confirmed
+              // just notify the other user that this one has accepted
+              const partnerId = currentUserId === match.user1Id ? match.user2Id : match.user1Id;
+              sendWebSocketMessage(partnerId, {type: 'partner_accepted'});
             }
           }
           break;


### PR DESCRIPTION
- Add display for a state where a match is confirmed and the user is redirecting to the session 
- Remove the user online and average wait time in matchingStatusModal
- Fix matchingService not seneding partner_accepted message to the web socket connection